### PR TITLE
Drop unused context parameter

### DIFF
--- a/deletiontests/azure/azure_delete_test.go
+++ b/deletiontests/azure/azure_delete_test.go
@@ -38,7 +38,7 @@ func Test_AzureDelete(t *testing.T) {
 		return
 	}
 
-	cpCtrlClient, err := ctrlclient.CreateCPCtrlClient(ctx)
+	cpCtrlClient, err := ctrlclient.CreateCPCtrlClient()
 	if err != nil {
 		t.Fatalf("error creating CP k8s client: %v", err)
 	}

--- a/pkg/ctrlclient/client.go
+++ b/pkg/ctrlclient/client.go
@@ -1,7 +1,6 @@
 package ctrlclient
 
 import (
-	"context"
 	"os"
 
 	"github.com/giantswarm/microerror"
@@ -15,7 +14,7 @@ const (
 	TenantClusterKubeconfigContents = "TC_KUBECONFIG"
 )
 
-func GetCPKubeConfig(ctx context.Context) ([]byte, error) {
+func GetCPKubeConfig() ([]byte, error) {
 	kubeConfig, exists := os.LookupEnv(ControlPlaneKubeconfigContents)
 	if !exists {
 		return nil, microerror.Maskf(missingEnvironmentVariable, "the %s env var is required", ControlPlaneKubeconfigContents)
@@ -24,7 +23,7 @@ func GetCPKubeConfig(ctx context.Context) ([]byte, error) {
 	return []byte(kubeConfig), nil
 }
 
-func GetTCKubeConfig(ctx context.Context) ([]byte, error) {
+func GetTCKubeConfig() ([]byte, error) {
 	kubeConfig, exists := os.LookupEnv(TenantClusterKubeconfigContents)
 	if !exists {
 		return nil, microerror.Maskf(missingEnvironmentVariable, "the %s env var is required", TenantClusterKubeconfigContents)
@@ -33,8 +32,8 @@ func GetTCKubeConfig(ctx context.Context) ([]byte, error) {
 	return []byte(kubeConfig), nil
 }
 
-func CreateTCCtrlClient(ctx context.Context) (client.Client, error) {
-	kubeConfig, err := GetTCKubeConfig(ctx)
+func CreateTCCtrlClient() (client.Client, error) {
+	kubeConfig, err := GetTCKubeConfig()
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -47,8 +46,8 @@ func CreateTCCtrlClient(ctx context.Context) (client.Client, error) {
 	return client.New(rest.CopyConfig(restConfig), client.Options{Scheme: Scheme})
 }
 
-func CreateCPCtrlClient(ctx context.Context) (client.Client, error) {
-	kubeConfig, err := GetCPKubeConfig(ctx)
+func CreateCPCtrlClient() (client.Client, error) {
+	kubeConfig, err := GetCPKubeConfig()
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/tests/autoscaler/autoscaler_test.go
+++ b/tests/autoscaler/autoscaler_test.go
@@ -28,7 +28,7 @@ func Test_Autoscaler(t *testing.T) {
 
 	ctx := context.Background()
 
-	tcCtrlClient, err := ctrlclient.CreateTCCtrlClient(ctx)
+	tcCtrlClient, err := ctrlclient.CreateTCCtrlClient()
 	if err != nil {
 		t.Fatalf("error creating TC k8s client: %v", err)
 	}

--- a/tests/cptcconnectivity/cptcconnectivity_test.go
+++ b/tests/cptcconnectivity/cptcconnectivity_test.go
@@ -26,7 +26,7 @@ func Test_CPTCConnectivity(t *testing.T) {
 
 	ctx := context.Background()
 
-	cpCtrlClient, err := ctrlclient.CreateCPCtrlClient(ctx)
+	cpCtrlClient, err := ctrlclient.CreateCPCtrlClient()
 	if err != nil {
 		t.Fatalf("error creating CP k8s client: %v", err)
 	}

--- a/tests/ingress/ingress_test.go
+++ b/tests/ingress/ingress_test.go
@@ -40,7 +40,7 @@ func Test_Ingress(t *testing.T) {
 
 	ctx := context.Background()
 
-	cpCtrlClient, err := ctrlclient.CreateCPCtrlClient(ctx)
+	cpCtrlClient, err := ctrlclient.CreateCPCtrlClient()
 	if err != nil {
 		t.Fatalf("error creating CP k8s client: %v", err)
 	}
@@ -55,12 +55,12 @@ func Test_Ingress(t *testing.T) {
 		t.Fatal("missing CLUSTER_ID environment variable")
 	}
 
-	cpKubeConfig, err := ctrlclient.GetCPKubeConfig(ctx)
+	cpKubeConfig, err := ctrlclient.GetCPKubeConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	tcKubeConfig, err := ctrlclient.GetTCKubeConfig(ctx)
+	tcKubeConfig, err := ctrlclient.GetTCKubeConfig()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
K8s client creation functions don't use the passed context variable.
Drop it.