### PR TITLE
Add helper package for CAPI related functions

### DIFF
--- a/pkg/capiutil/cluster.go
+++ b/pkg/capiutil/cluster.go
@@ -1,0 +1,28 @@
+package capiutil
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func FindCluster(ctx context.Context, client ctrl.Client, clusterID string) (*capi.Cluster, error) {
+	var cluster *capi.Cluster
+	{
+		var clusterList capi.ClusterList
+		err := client.List(ctx, &clusterList, ctrl.MatchingLabels{capi.ClusterLabelName: clusterID})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if len(clusterList.Items) > 0 {
+			cluster = &clusterList.Items[0]
+		} else {
+			return nil, microerror.Maskf(notFoundError, "can't find cluster with ID %q", clusterID)
+		}
+	}
+
+	return cluster, nil
+}

--- a/pkg/capiutil/error.go
+++ b/pkg/capiutil/error.go
@@ -1,0 +1,12 @@
+package capiutil
+
+import "github.com/giantswarm/microerror"
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}


### PR DESCRIPTION
Add new `capiutil` package to hold CAPI related helper functions such as
finding `Cluster`.