### PR TITLE
Add: Provider support & initial version for Azure

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -1,0 +1,188 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/reference"
+	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	expcapz "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapi "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/azure"
+	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/azure/credentials"
+)
+
+const (
+	defaultVMSize = "Standard_D4s_v3"
+)
+
+type AzureProviderSupport struct {
+	azureClient *azure.Client
+}
+
+func NewAzureProviderSupport(ctx context.Context, client ctrl.Client, cluster *capi.Cluster) (Support, error) {
+	sp, err := credentials.ForCluster(ctx, client, cluster)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	azureClient, err := azure.NewClient(azure.ClientConfig{ServicePrincipal: sp})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	p := &AzureProviderSupport{
+		azureClient: azureClient,
+	}
+
+	return p, nil
+}
+
+func (p *AzureProviderSupport) CreateNodePool(ctx context.Context, client ctrl.Client, cluster *capi.Cluster, azs []string) (*expcapi.MachinePool, error) {
+	azureMP, err := p.createAzureMachinePool(ctx, client, cluster, azs)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	mp, err := p.createMachinePool(ctx, client, cluster, azureMP, azs)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return mp, nil
+}
+
+func (p *AzureProviderSupport) GetProviderAZs() []string {
+	return []string{"1", "2", "3"}
+}
+
+func (p *AzureProviderSupport) GetNodePoolAZs(ctx context.Context, clusterID, nodepoolID string) ([]string, error) {
+	var zones []string
+	nodepoolVMSSName := fmt.Sprintf("nodepool-%s", nodepoolID)
+	vmss, err := p.azureClient.VMSS.Get(ctx, clusterID, nodepoolVMSSName)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if vmss.Zones != nil {
+		zones = *vmss.Zones
+	}
+
+	return zones, nil
+}
+
+func (p *AzureProviderSupport) createMachinePool(ctx context.Context, client ctrl.Client, cluster *capi.Cluster, azureMachinePool *expcapz.AzureMachinePool, azs []string) (*expcapi.MachinePool, error) {
+	var infrastructureCRRef *corev1.ObjectReference
+	{
+		s := runtime.NewScheme()
+		err := expcapz.AddToScheme(s)
+		if err != nil {
+			panic(fmt.Sprintf("expcapz.AddToScheme: %+v", err))
+		}
+
+		infrastructureCRRef, err = reference.GetReference(s, azureMachinePool)
+		if err != nil {
+			panic(fmt.Sprintf("cannot create reference to infrastructure CR: %q", err))
+		}
+	}
+
+	machinePool := &expcapi.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      azureMachinePool.Name,
+			Namespace: azureMachinePool.Namespace,
+			Labels: map[string]string{
+				label.AzureOperatorVersion: cluster.Labels[label.AzureOperatorVersion],
+				label.Cluster:              cluster.Labels[label.Cluster],
+				capi.ClusterLabelName:      cluster.Labels[capi.ClusterLabelName],
+				label.MachinePool:          azureMachinePool.Labels[label.MachinePool],
+				label.Organization:         cluster.Labels[label.Organization],
+				label.ReleaseVersion:       cluster.Labels[label.ReleaseVersion],
+			},
+			Annotations: map[string]string{
+				annotation.MachinePoolName: "availability zone verification e2e test",
+				annotation.NodePoolMinSize: fmt.Sprintf("%d", len(azs)),
+				annotation.NodePoolMaxSize: fmt.Sprintf("%d", len(azs)),
+			},
+		},
+		Spec: expcapi.MachinePoolSpec{
+			ClusterName:    cluster.Name,
+			Replicas:       to.Int32Ptr(int32(len(azs))),
+			FailureDomains: azs,
+			Template: capi.MachineTemplateSpec{
+				Spec: capi.MachineSpec{
+					ClusterName:       cluster.Name,
+					InfrastructureRef: *infrastructureCRRef,
+				},
+			},
+		},
+	}
+
+	err := client.Create(ctx, machinePool)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return machinePool, nil
+}
+
+func (p *AzureProviderSupport) createAzureMachinePool(ctx context.Context, client ctrl.Client, cluster *capi.Cluster, azs []string) (*expcapz.AzureMachinePool, error) {
+	azureCluster := &capz.AzureCluster{}
+	{
+		n := cluster.Spec.InfrastructureRef.Name
+		ns := cluster.Spec.InfrastructureRef.Namespace
+		err := client.Get(ctx, ctrl.ObjectKey{Name: n, Namespace: ns}, azureCluster)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	azureMachinePool := &expcapz.AzureMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "e2etst",
+			Namespace: cluster.Namespace,
+			Labels: map[string]string{
+				label.AzureOperatorVersion: cluster.Labels[label.AzureOperatorVersion],
+				label.Cluster:              cluster.Labels[label.Cluster],
+				capi.ClusterLabelName:      cluster.Name,
+				label.MachinePool:          "e2etst",
+				label.Organization:         cluster.Labels[label.Organization],
+				label.ReleaseVersion:       cluster.Labels[label.ReleaseVersion],
+			},
+		},
+		Spec: expcapz.AzureMachinePoolSpec{
+			Location: azureCluster.Spec.Location,
+			Template: expcapz.AzureMachineTemplate{
+				DataDisks: []capz.DataDisk{
+					{
+						NameSuffix: "docker",
+						DiskSizeGB: int32(100),
+						Lun:        to.Int32Ptr(21),
+					},
+					{
+						NameSuffix: "kubelet",
+						DiskSizeGB: int32(100),
+						Lun:        to.Int32Ptr(22),
+					},
+				},
+				VMSize: defaultVMSize,
+			},
+		},
+	}
+
+	err := client.Create(ctx, azureMachinePool)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return azureMachinePool, nil
+}

--- a/pkg/provider/common.go
+++ b/pkg/provider/common.go
@@ -1,0 +1,28 @@
+package provider
+
+import (
+	"context"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	Provider = "E2E_PROVIDER"
+)
+
+func GetProviderSupport(ctx context.Context, client ctrl.Client, cluster *capi.Cluster) (Support, error) {
+	switch os.Getenv(Provider) {
+	case "azure":
+		p, err := NewAzureProviderSupport(ctx, client, cluster)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		return p, nil
+	}
+
+	return nil, microerror.Maskf(executionFailedError, "unsupported provider")
+}

--- a/pkg/provider/common.go
+++ b/pkg/provider/common.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -14,7 +15,9 @@ const (
 )
 
 func GetProviderSupport(ctx context.Context, client ctrl.Client, cluster *capi.Cluster) (Support, error) {
-	switch os.Getenv(Provider) {
+	provider := os.Getenv(Provider)
+
+	switch strings.TrimSpace(provider) {
 	case "azure":
 		p, err := NewAzureProviderSupport(ctx, client, cluster)
 		if err != nil {
@@ -24,5 +27,5 @@ func GetProviderSupport(ctx context.Context, client ctrl.Client, cluster *capi.C
 		return p, nil
 	}
 
-	return nil, microerror.Maskf(executionFailedError, "unsupported provider")
+	return nil, microerror.Maskf(executionFailedError, "unsupported provider value in $%s: %q", Provider, provider)
 }

--- a/pkg/provider/error.go
+++ b/pkg/provider/error.go
@@ -1,0 +1,12 @@
+package provider
+
+import "github.com/giantswarm/microerror"
+
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}

--- a/pkg/provider/spec.go
+++ b/pkg/provider/spec.go
@@ -1,0 +1,15 @@
+package provider
+
+import (
+	"context"
+
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapi "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Support interface {
+	CreateNodePool(ctx context.Context, client ctrl.Client, cluster *capi.Cluster, azs []string) (*expcapi.MachinePool, error)
+	GetProviderAZs() []string
+	GetNodePoolAZs(ctx context.Context, clusterID, nodepoolName string) ([]string, error)
+}


### PR DESCRIPTION
This adds initial structure for provider specific support
implementation. `provider.Support` is meant to be used for provider
specific functionality that can be used for implementing tests in
provider independent way.

Initial Azure support is also included, as extracted from upcoming
multi-AZ test.