### PR TITLE
Fail when tests fail

### DIFF
--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -o pipefail
+
 results_dir="${RESULTS_DIR:-/tmp/results}"
 
 # saveResults prepares the results for handoff to the Sonobuoy worker.

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-set -o pipefail
+set -eo pipefail
 
 results_dir="${RESULTS_DIR:-/tmp/results}"
 


### PR DESCRIPTION
Using `tee` to collect `go test` logs has the side effect of losing the exit code. We need the exit code of `go test`, so we need the `pipefail` option in the bash script. It's only available in bash,  that's why I changed the interpreter.