### PR TITLE
retry to update the deployment to overcome conflict errors

### DIFF
--- a/tests/autoscaler/autoscaler_test.go
+++ b/tests/autoscaler/autoscaler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/micrologger"
@@ -115,15 +116,29 @@ func getWorkersCount(ctx context.Context, ctrlClient client.Client) (int, error)
 }
 
 func scaleDeployment(ctx context.Context, ctrlClient client.Client, expectedWorkersCount int32) error {
-	deployment := &appsv1.Deployment{}
-	err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: helloWorldNamespace, Name: helloWorldDeploymentName}, deployment)
-	if err != nil {
-		return microerror.Mask(err)
+	o := func() error {
+		deployment := &appsv1.Deployment{}
+		err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: helloWorldNamespace, Name: helloWorldDeploymentName}, deployment)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		deployment.Spec.Replicas = &expectedWorkersCount
+
+		err = ctrlClient.Update(ctx, deployment)
+		if apierrors.IsConflict(err) {
+			// Retriable error.
+			return microerror.Mask(err)
+		} else if err != nil {
+			// Wrap masked error with backoff.Permanent() to stop retries on unrecoverable error.
+			return backoff.Permanent(microerror.Mask(err))
+		}
+
+		return nil
 	}
 
-	deployment.Spec.Replicas = &expectedWorkersCount
-
-	err = ctrlClient.Update(ctx, deployment)
+	b := backoff.NewConstant(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+	err := backoff.Retry(o, b)
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
during autoscaling test it happened that the replicas change in the deployment causes a conflict error.
This pr adds a backoff retry to avoid this from making the whole test to fail