### PR TITLE
Always pull plugins' docker image

### DIFF
--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -4,6 +4,7 @@ sonobuoy-config:
   result-format: raw
 spec:
   image: quay.io/giantswarm/sonobuoy-plugin
+  imagePullPolicy: Always
   name: plugin
   env:
     - name: TC_KUBECONFIG


### PR DESCRIPTION
We always want to run the latest version of the plugins' docker image.