### PR TITLE
Generate junit report so that sonobuoy parses the result

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY go.mod .
 COPY go.sum .
 
-RUN go mod download
+RUN go get -u github.com/jstemmer/go-junit-report && go mod download
 
 COPY . .
 RUN go build ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ WORKDIR /app
 COPY go.mod .
 COPY go.sum .
 
-RUN go get -u github.com/jstemmer/go-junit-report && go mod download
+RUN go get -u github.com/jstemmer/go-junit-report \
+  && apt-get update && apt-get install -y nodejs npm \
+  && npm install -g junit-report-merger \
+  && go mod download
 
 COPY . .
 RUN go build ./...

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: giantswarm
   result-format: junit
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-300eee95b70bc35857424b54b45e61f3c5729d08
+  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-ca3b87aee2730984b16413f88f0582d8f20e15e7
   imagePullPolicy: Always
   name: plugin
   env:

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: giantswarm
   result-format: raw
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin
+  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-2583bd62a1b1bfac286f919cd2a9f75e29c4d354
   imagePullPolicy: Always
   name: plugin
   env:

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: giantswarm
   result-format: junit
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-291085da72471b816519288e7749b29811b48c7b
+  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-561e9017d54c2e17196a1700b1f6fbb8763d6c76
   imagePullPolicy: Always
   name: plugin
   env:

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: giantswarm
   result-format: junit
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-df70337d1c643b54c0d2e7274d1f578f147d2111
+  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-06e15208f5205b7a65937c6c238a91bc20a3031d
   imagePullPolicy: Always
   name: plugin
   env:

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: giantswarm
   result-format: junit
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-6646c4a30b9be32cbfff363d43c02592c4fe42c6
+  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-df70337d1c643b54c0d2e7274d1f578f147d2111
   imagePullPolicy: Always
   name: plugin
   env:

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: giantswarm
   result-format: junit
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-0f5bfeab9238c42f6749189f4c3ce0b6e25aa3f8
+  image: quay.io/giantswarm/sonobuoy-plugin
   imagePullPolicy: Always
   name: plugin
   env:

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: giantswarm
   result-format: raw
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-2583bd62a1b1bfac286f919cd2a9f75e29c4d354
+  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-cf6ce28facd45656b32724fac53f2f90ca188693
   imagePullPolicy: Always
   name: plugin
   env:

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: giantswarm
   result-format: junit
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-561e9017d54c2e17196a1700b1f6fbb8763d6c76
+  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-0f5bfeab9238c42f6749189f4c3ce0b6e25aa3f8
   imagePullPolicy: Always
   name: plugin
   env:

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -1,9 +1,9 @@
 sonobuoy-config:
   driver: Job
   plugin-name: giantswarm
-  result-format: raw
+  result-format: junit
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-cf6ce28facd45656b32724fac53f2f90ca188693
+  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-300eee95b70bc35857424b54b45e61f3c5729d08
   imagePullPolicy: Always
   name: plugin
   env:

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: giantswarm
   result-format: junit
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-ca3b87aee2730984b16413f88f0582d8f20e15e7
+  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-6646c4a30b9be32cbfff363d43c02592c4fe42c6
   imagePullPolicy: Always
   name: plugin
   env:

--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: giantswarm
   result-format: junit
 spec:
-  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-06e15208f5205b7a65937c6c238a91bc20a3031d
+  image: quay.io/giantswarm/sonobuoy-plugin:0.0.0-291085da72471b816519288e7749b29811b48c7b
   imagePullPolicy: Always
   name: plugin
   env:

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -9,7 +9,7 @@ junit_report_file="${results_dir}/report.xml"
 # See: https://github.com/vmware-tanzu/sonobuoy/blob/master/site/docs/master/plugins.md
 saveResults() {
 	# Signal to the worker that we are done and where to find the results.
-	printf ${junit_report_file > "${results_dir}/done"
+	printf ${junit_report_file} > "${results_dir}/done"
 }
 
 # Ensure that we tell the Sonobuoy worker we are done regardless of results.

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -22,8 +22,12 @@ echo "Report will be saved to ${junit_report_file}"
 # Run all tests.
 go test -v -timeout 99999s ./tests/availabilityzones 2>&1 | go-junit-report > "${results_dir}/report.xml"
 
+ls -lah "${results_dir}"
+
 # Run the deletion test (tiers down the cluster).
 go test -v -timeout 99999s ./deletiontests/... 2>&1 | go-junit-report > "${results_dir}/deletiontests.xml"
+
+ls -lah "${results_dir}"
 
 jrm "${junit_report_file}" "${results_dir}/report.xml" "${results_dir}/deletiontests.xml"
 

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -6,10 +6,10 @@ results_dir="${RESULTS_DIR:-/tmp/results}"
 junit_report_file="${results_dir}/report.xml"
 
 # saveResults prepares the results for handoff to the Sonobuoy worker.
-# See: https://github.com/vmware-tanzu/sonobuoy/blob/master/docs/plugins.md
+# See: https://github.com/vmware-tanzu/sonobuoy/blob/master/site/docs/master/plugins.md
 saveResults() {
 	# Signal to the worker that we are done and where to find the results.
-	printf ${results_dir}/out > "${results_dir}/done"
+	printf ${junit_report_file > "${results_dir}/done"
 }
 
 # Ensure that we tell the Sonobuoy worker we are done regardless of results.

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -20,9 +20,9 @@ mkdir "${results_dir}" || true
 echo "Report will be saved to ${junit_report_file}"
 
 # Run all tests.
-go test -v -timeout 99999s ./tests/autoscaler 2>&1 | go-junit-report > "${results_dir}/report.xml"
+go test -v -timeout 99999s ./tests/... 2>&1 | go-junit-report > "${results_dir}/report.xml"
 
 # Run the deletion test (tiers down the cluster).
-go test -v -timeout 99999s ./deletiontests/... | go-junit-report >> "${results_dir}/deletiontests.xml"
+go test -v -timeout 99999s ./deletiontests/... 2>&1 | go-junit-report > "${results_dir}/deletiontests.xml"
 
 jrm "${junit_report_file}" "${results_dir}/report.xml" "${results_dir}/deletiontests.xml"

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 results_dir="${RESULTS_DIR:-/tmp/results}"
-junit_report_file="${results_dir}/report.xml"
+junit_report_file="${results_dir}/combined-report.xml"
 
 # saveResults prepares the results for handoff to the Sonobuoy worker.
 # See: https://github.com/vmware-tanzu/sonobuoy/blob/master/site/docs/master/plugins.md
@@ -20,7 +20,9 @@ mkdir "${results_dir}" || true
 echo "Report will be saved to ${junit_report_file}"
 
 # Run all tests.
-go test -v -timeout 99999s ./tests/autoscaler 2>&1 | go-junit-report > "${junit_report_file}"
+go test -v -timeout 99999s ./tests/autoscaler 2>&1 | go-junit-report > "${results_dir}/report.xml"
 
 # Run the deletion test (tiers down the cluster).
-#go test -v -timeout 99999s ./deletiontests/... | go-junit-report >> "${junit_report_file}"
+go test -v -timeout 99999s ./deletiontests/... | go-junit-report >> "${results_dir}/deletiontests.xml"
+
+jrm "${junit_report_file}" "${results_dir}/report.xml" "${results_dir}/deletiontests.xml"

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -16,6 +16,8 @@ trap saveResults EXIT
 
 mkdir "${results_dir}" || true
 
+exit 1
+
 # Run all tests.
 go test -v -timeout 99999s ./tests/... 2>&1 | tee -a "${results_dir}/out"
 

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -6,8 +6,8 @@ junit_report_file="${results_dir}/combined-report.xml"
 # saveResults prepares the results for handoff to the Sonobuoy worker.
 # See: https://github.com/vmware-tanzu/sonobuoy/blob/master/site/docs/master/plugins.md
 saveResults() {
-	# Signal to the worker that we are done and where to find the results.
-	printf ${junit_report_file} > "${results_dir}/done"
+  # Signal to the worker that we are done and where to find the results.
+  printf ${junit_report_file} >"${results_dir}/done"
 }
 
 # Ensure that we tell the Sonobuoy worker we are done regardless of results.
@@ -15,20 +15,10 @@ trap saveResults EXIT
 
 mkdir "${results_dir}" || true
 
-echo "Report will be saved to ${junit_report_file}"
-
 # Run all tests.
-go test -v -timeout 99999s ./tests/availabilityzones 2>&1 | go-junit-report > "${results_dir}/report.xml"
-
-ls -lah "${results_dir}"
+go test -v -timeout 99999s ./tests/... 2>&1 | go-junit-report >"${results_dir}/report.xml"
 
 # Run the deletion test (tiers down the cluster).
-go test -v -timeout 99999s ./deletiontests/... 2>&1 | go-junit-report > "${results_dir}/deletiontests.xml"
-
-ls -lah "${results_dir}"
+go test -v -timeout 99999s ./deletiontests/... 2>&1 | go-junit-report >"${results_dir}/deletiontests.xml"
 
 jrm "${junit_report_file}" "${results_dir}/report.xml" "${results_dir}/deletiontests.xml"
-
-ls -lah "${results_dir}"
-
-cat "${junit_report_file}"

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
-
 results_dir="${RESULTS_DIR:-/tmp/results}"
 junit_report_file="${results_dir}/combined-report.xml"
 

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -20,9 +20,13 @@ mkdir "${results_dir}" || true
 echo "Report will be saved to ${junit_report_file}"
 
 # Run all tests.
-go test -v -timeout 99999s ./tests/... 2>&1 | go-junit-report > "${results_dir}/report.xml"
+go test -v -timeout 99999s ./tests/availabilityzones 2>&1 | go-junit-report > "${results_dir}/report.xml"
 
 # Run the deletion test (tiers down the cluster).
 go test -v -timeout 99999s ./deletiontests/... 2>&1 | go-junit-report > "${results_dir}/deletiontests.xml"
 
 jrm "${junit_report_file}" "${results_dir}/report.xml" "${results_dir}/deletiontests.xml"
+
+ls -lah "${results_dir}"
+
+cat "${junit_report_file}"

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -17,8 +17,10 @@ trap saveResults EXIT
 
 mkdir "${results_dir}" || true
 
+echo "Report will be saved to ${junit_report_file}"
+
 # Run all tests.
-go test -v -timeout 99999s ./tests/... 2>&1 | go-junit-report > "${junit_report_file}"
+go test -v -timeout 99999s ./tests/autoscaler 2>&1 | go-junit-report > "${junit_report_file}"
 
 # Run the deletion test (tiers down the cluster).
-#go test -v -timeout 99999s ./deletiontests/... 2>&1 | go-junit-report >> "${junit_report_file}"
+#go test -v -timeout 99999s ./deletiontests/... | go-junit-report >> "${junit_report_file}"

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -3,6 +3,7 @@
 set -eo pipefail
 
 results_dir="${RESULTS_DIR:-/tmp/results}"
+junit_report_file="${results_dir}/report.xml"
 
 # saveResults prepares the results for handoff to the Sonobuoy worker.
 # See: https://github.com/vmware-tanzu/sonobuoy/blob/master/docs/plugins.md
@@ -16,10 +17,8 @@ trap saveResults EXIT
 
 mkdir "${results_dir}" || true
 
-exit 1
-
 # Run all tests.
-go test -v -timeout 99999s ./tests/... 2>&1 | tee -a "${results_dir}/out"
+go test -v -timeout 99999s ./tests/... 2>&1 | go-junit-report > "${junit_report_file}"
 
 # Run the deletion test (tiers down the cluster).
-go test -v -timeout 99999s ./deletiontests/... 2>&1 | tee -a "${results_dir}/out"
+#go test -v -timeout 99999s ./deletiontests/... 2>&1 | go-junit-report >> "${junit_report_file}"


### PR DESCRIPTION
We need to install:
- tool to generate `junit` report from `go test` output, because that's what `sonobuoy` understands.
- `nodejs` tool to merge together different `junit` reports, because we generate one for the `deletion` test and one for the rest.