### PR TITLE
Adjust tests' timeout value

### DIFF
--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -16,9 +16,9 @@ trap saveResults EXIT
 mkdir "${results_dir}" || true
 
 # Run all tests.
-go test -v -timeout 99999s ./tests/... 2>&1 | go-junit-report >"${results_dir}/report.xml"
+go test -v -timeout 6h ./tests/... 2>&1 | go-junit-report >"${results_dir}/report.xml"
 
-# Run the deletion test (tiers down the cluster).
-go test -v -timeout 99999s ./deletiontests/... 2>&1 | go-junit-report >"${results_dir}/deletiontests.xml"
+# Run the deletion test (tear down the cluster).
+go test -v -timeout 2h ./deletiontests/... 2>&1 | go-junit-report >"${results_dir}/deletiontests.xml"
 
 jrm "${junit_report_file}" "${results_dir}/report.xml" "${results_dir}/deletiontests.xml"


### PR DESCRIPTION
`-timeout` value is duration string so it understands hours as well.
Less than 24h is also better value in case we run nightly tests at one
point.