### PR TITLE
Don't wait that long before failing

### DIFF
--- a/pkg/capiutil/common.go
+++ b/pkg/capiutil/common.go
@@ -58,7 +58,7 @@ func WaitForCondition(t *testing.T, ctx context.Context, logger micrologger.Logg
 		}
 	}
 
-	b := backoff.NewExponential(backoff.LongMaxWait, retryInterval)
+	b := backoff.NewExponential(backoff.MediumMaxWait, retryInterval)
 	n := backoff.NewNotifier(logger, ctx)
 	err := backoff.RetryNotify(o, b, n)
 	if err != nil {

--- a/tests/autoscaler/autoscaler_test.go
+++ b/tests/autoscaler/autoscaler_test.go
@@ -77,7 +77,7 @@ func Test_Autoscaler(t *testing.T) {
 
 		return nil
 	}
-	b := backoff.NewConstant(backoff.LongMaxWait, 10*time.Second)
+	b := backoff.NewConstant(5 * time.Minute, 10*time.Second)
 	n := backoff.NewNotifier(logger, ctx)
 	err = backoff.RetryNotify(o, b, n)
 	if err != nil {
@@ -92,6 +92,7 @@ func Test_Autoscaler(t *testing.T) {
 		cleanupAndFatal(ctx, deployment, tcCtrlClient, t, "timeout waiting for cluster to scale down: %v", err)
 	}
 
+	b = backoff.NewConstant(20 * time.Minute, 10*time.Second)
 	err = backoff.RetryNotify(o, b, n)
 	if err != nil {
 		cleanupAndFatal(ctx, deployment, tcCtrlClient, t, "timeout waiting for cluster to scale down: %v", err)

--- a/tests/availabilityzones/multiaz_test.go
+++ b/tests/availabilityzones/multiaz_test.go
@@ -64,7 +64,7 @@ func Test_AvailabilityZones(t *testing.T) {
 
 			return nil
 		}
-		b := backoff.NewConstant(backoff.LongMaxWait, backoff.LongMaxInterval)
+		b := backoff.NewConstant(backoff.MediumMaxWait, backoff.LongMaxInterval)
 		n := backoff.NewNotifier(microloggertest.New(), ctx)
 		err = backoff.RetryNotify(o, b, n)
 		if err != nil {


### PR DESCRIPTION
We use the retry mechanism in several places of our tests. When something goes wrong, the retry mechanism will wait up until the specified parameter. Let's try to choose deliberate the amount of time, instead of just defaulting to "a long time".

Do you think this is enough time? 