### PR TITLE
Conditionally run the deletion cluster test

### DIFF
--- a/giantswarm-plugin.yaml
+++ b/giantswarm-plugin.yaml
@@ -11,6 +11,7 @@ spec:
     - name: CP_KUBECONFIG
     - name: CLUSTER_ID
     - name: PROVIDER
+    - name: TEST_DELETION
   resources: { }
   volumeMounts:
     - mountPath: /tmp/results

--- a/run_go_test.sh
+++ b/run_go_test.sh
@@ -18,7 +18,11 @@ mkdir "${results_dir}" || true
 # Run all tests.
 go test -v -timeout 6h ./tests/... 2>&1 | go-junit-report >"${results_dir}/report.xml"
 
-# Run the deletion test (tear down the cluster).
-go test -v -timeout 2h ./deletiontests/... 2>&1 | go-junit-report >"${results_dir}/deletiontests.xml"
+cp "${results_dir}/report.xml" "${junit_report_file}"
 
-jrm "${junit_report_file}" "${results_dir}/report.xml" "${results_dir}/deletiontests.xml"
+if [[ $TEST_DELETION -eq 1 ]]; then
+  # Run the deletion test (tear down the cluster).
+  go test -v -timeout 2h ./deletiontests/... 2>&1 | go-junit-report >"${results_dir}/deletiontests.xml"
+
+  jrm "${junit_report_file}" "${results_dir}/report.xml" "${results_dir}/deletiontests.xml"
+fi


### PR DESCRIPTION
When we are debugging the tests, it would be useful to keep the resources that got created, instead of deleting everything. We need to conditionally run the deletion cluster test.