### PR TITLE
Change interface so it does not lead to infinite recursion

### DIFF
--- a/pkg/azure/internal/client/vmss.go
+++ b/pkg/azure/internal/client/vmss.go
@@ -24,6 +24,7 @@ func NewVMSSClient(authorizer autorest.Authorizer, subscriptionID string) *VMSSC
 	}
 }
 
-func (c *VMSSClient) Get(ctx context.Context, resourceGroupName, vmssName string) (VMSS, error) {
-	return c.Get(ctx, resourceGroupName, vmssName)
+func (c *VMSSClient) GetVMSS(ctx context.Context, resourceGroupName, vmssName string) (VMSS, error) {
+	vmss, err := c.Get(ctx, resourceGroupName, vmssName)
+	return &vmss, err
 }

--- a/pkg/azure/spec.go
+++ b/pkg/azure/spec.go
@@ -7,5 +7,5 @@ type ResourceGroupsClient interface {
 }
 
 type VMSSClient interface {
-	Get(ctx context.Context, resourceGroupName, vmssName string) (VMSS, error)
+	GetVMSS(ctx context.Context, resourceGroupName, vmssName string) (VMSS, error)
 }

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -76,7 +76,7 @@ func (p *AzureProviderSupport) GetProviderAZs() []string {
 func (p *AzureProviderSupport) GetNodePoolAZs(ctx context.Context, clusterID, nodepoolID string) ([]string, error) {
 	var zones []string
 	nodepoolVMSSName := fmt.Sprintf("nodepool-%s", nodepoolID)
-	vmss, err := p.azureClient.VMSS.Get(ctx, clusterID, nodepoolVMSSName)
+	vmss, err := p.azureClient.VMSS.GetVMSS(ctx, clusterID, nodepoolVMSSName)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}


### PR DESCRIPTION
I got a panic while running the tests, I believe it's an stack overflow due to recursion.

<details>
  <summary>Stack trace</summary>

  ```
    /usr/local/go/src/runtime/panic.go:1116 +0x72
    /usr/local/go/src/runtime/stack.go:1067 +0x78d
    /usr/local/go/src/runtime/asm_amd64.s:449 +0x8f
    /app/pkg/azure/internal/client/vmss.go:27 +0xaa fp=0xc02106a380 sp=0xc02106a378 pc=0x14e65aa
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a3e0 sp=0xc02106a380 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a440 sp=0xc02106a3e0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a4a0 sp=0xc02106a440 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a500 sp=0xc02106a4a0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a560 sp=0xc02106a500 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a5c0 sp=0xc02106a560 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a620 sp=0xc02106a5c0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a680 sp=0xc02106a620 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a6e0 sp=0xc02106a680 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a740 sp=0xc02106a6e0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a7a0 sp=0xc02106a740 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a800 sp=0xc02106a7a0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a860 sp=0xc02106a800 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a8c0 sp=0xc02106a860 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a920 sp=0xc02106a8c0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a980 sp=0xc02106a920 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106a9e0 sp=0xc02106a980 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106aa40 sp=0xc02106a9e0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106aaa0 sp=0xc02106aa40 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ab00 sp=0xc02106aaa0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ab60 sp=0xc02106ab00 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106abc0 sp=0xc02106ab60 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ac20 sp=0xc02106abc0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ac80 sp=0xc02106ac20 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ace0 sp=0xc02106ac80 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ad40 sp=0xc02106ace0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ada0 sp=0xc02106ad40 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ae00 sp=0xc02106ada0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ae60 sp=0xc02106ae00 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106aec0 sp=0xc02106ae60 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106af20 sp=0xc02106aec0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106af80 sp=0xc02106af20 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106afe0 sp=0xc02106af80 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b040 sp=0xc02106afe0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b0a0 sp=0xc02106b040 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b100 sp=0xc02106b0a0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b160 sp=0xc02106b100 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b1c0 sp=0xc02106b160 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b220 sp=0xc02106b1c0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b280 sp=0xc02106b220 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b2e0 sp=0xc02106b280 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b340 sp=0xc02106b2e0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b3a0 sp=0xc02106b340 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b400 sp=0xc02106b3a0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b460 sp=0xc02106b400 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b4c0 sp=0xc02106b460 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b520 sp=0xc02106b4c0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b580 sp=0xc02106b520 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b5e0 sp=0xc02106b580 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b640 sp=0xc02106b5e0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b6a0 sp=0xc02106b640 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b700 sp=0xc02106b6a0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b760 sp=0xc02106b700 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b7c0 sp=0xc02106b760 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b820 sp=0xc02106b7c0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b880 sp=0xc02106b820 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b8e0 sp=0xc02106b880 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b940 sp=0xc02106b8e0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106b9a0 sp=0xc02106b940 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ba00 sp=0xc02106b9a0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106ba60 sp=0xc02106ba00 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bac0 sp=0xc02106ba60 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bb20 sp=0xc02106bac0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bb80 sp=0xc02106bb20 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bbe0 sp=0xc02106bb80 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bc40 sp=0xc02106bbe0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bca0 sp=0xc02106bc40 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bd00 sp=0xc02106bca0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bd60 sp=0xc02106bd00 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bdc0 sp=0xc02106bd60 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106be20 sp=0xc02106bdc0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106be80 sp=0xc02106be20 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bee0 sp=0xc02106be80 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bf40 sp=0xc02106bee0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106bfa0 sp=0xc02106bf40 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c000 sp=0xc02106bfa0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c060 sp=0xc02106c000 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c0c0 sp=0xc02106c060 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c120 sp=0xc02106c0c0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c180 sp=0xc02106c120 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c1e0 sp=0xc02106c180 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c240 sp=0xc02106c1e0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c2a0 sp=0xc02106c240 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c300 sp=0xc02106c2a0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c360 sp=0xc02106c300 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c3c0 sp=0xc02106c360 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c420 sp=0xc02106c3c0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c480 sp=0xc02106c420 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c4e0 sp=0xc02106c480 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c540 sp=0xc02106c4e0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c5a0 sp=0xc02106c540 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c600 sp=0xc02106c5a0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c660 sp=0xc02106c600 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c6c0 sp=0xc02106c660 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c720 sp=0xc02106c6c0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c780 sp=0xc02106c720 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c7e0 sp=0xc02106c780 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c840 sp=0xc02106c7e0 pc=0x14e6574
    /app/pkg/azure/internal/client/vmss.go:28 +0x74 fp=0xc02106c8a0 sp=0xc02106c840 pc=0x14e6574
    /usr/local/go/src/testing/testing.go:1168 +0x2b3
    /usr/local/go/src/testing/testing.go:1088 +0x24d
    /usr/local/go/src/testing/testing.go:1127 +0x125
    /usr/local/go/src/testing/testing.go:1437 +0x2fe
    /usr/local/go/src/testing/testing.go:1345 +0x1eb
    _testmain.go:57 +0x138
    /go/pkg/mod/k8s.io/klog@v1.0.0/klog.go:1010 +0x8b
    /go/pkg/mod/k8s.io/klog@v1.0.0/klog.go:411 +0xd8
    /go/pkg/mod/k8s.io/klog/v2@v2.0.0/klog.go:1107 +0x8b
    /go/pkg/mod/k8s.io/klog/v2@v2.0.0/klog.go:416 +0xd8
    /usr/local/go/src/testing/testing.go:1444 +0x3b
    /usr/local/go/src/testing/testing.go:1444 +0xac
    /usr/local/go/src/runtime/netpoll.go:220 +0x55
    /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
    /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
    /usr/local/go/src/internal/poll/fd_unix.go:159 +0x1a5
    /usr/local/go/src/net/fd_posix.go:55 +0x4f
    /usr/local/go/src/net/net.go:182 +0x8e
    /usr/local/go/src/crypto/tls/conn.go:779 +0x62
    /usr/local/go/src/bytes/buffer.go:204 +0xb1
    /usr/local/go/src/crypto/tls/conn.go:801 +0xf3
    /usr/local/go/src/crypto/tls/conn.go:608 +0x115
    /usr/local/go/src/crypto/tls/conn.go:576
    /usr/local/go/src/crypto/tls/conn.go:1252 +0x15f
    /usr/local/go/src/bufio/bufio.go:227 +0x222
    /usr/local/go/src/io/io.go:314 +0x87
    /usr/local/go/src/io/io.go:333
    /go/pkg/mod/golang.org/x/net@v0.0.0-20201002202402-0a1ea396d57c/http2/frame.go:237 +0x89
    /go/pkg/mod/golang.org/x/net@v0.0.0-20201002202402-0a1ea396d57c/http2/frame.go:492 +0xa5
    /go/pkg/mod/golang.org/x/net@v0.0.0-20201002202402-0a1ea396d57c/http2/transport.go:1794 +0xd8
    /go/pkg/mod/golang.org/x/net@v0.0.0-20201002202402-0a1ea396d57c/http2/transport.go:1716 +0x6f
    /go/pkg/mod/golang.org/x/net@v0.0.0-20201002202402-0a1ea396d57c/http2/transport.go:695 +0x66e
```
</details>
