### PR TITLE
Filter out testing node pools when asserting things

### DIFF
--- a/autoscaler_test.go
+++ b/autoscaler_test.go
@@ -74,6 +74,7 @@ func Test_Autoscaler(t *testing.T) {
 		for _, machinePool := range machinePools.Items {
 			if capiconditions.IsTrue(&machinePool, capi.ReadyCondition) {
 				machinePoolName = machinePool.Name
+				break
 			}
 		}
 

--- a/autoscaler_test.go
+++ b/autoscaler_test.go
@@ -57,7 +57,7 @@ func Test_Autoscaler(t *testing.T) {
 
 	var machinePoolName string
 	{
-		machinePools, err := capiutil.FindMachinePoolsForCluster(ctx, cpCtrlClient, clusterID)
+		machinePools, err := capiutil.FindNonTestingMachinePoolsForCluster(ctx, cpCtrlClient, clusterID)
 		if err != nil {
 			t.Fatalf("error finding MachinePools for cluster %q: %s", clusterID, microerror.JSON(err))
 		}

--- a/azurecluster_test.go
+++ b/azurecluster_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
 
 	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/assert"
@@ -80,7 +81,6 @@ func Test_AzureClusterCR(t *testing.T) {
 	assert.LabelIsSet(t, cluster, label.AzureOperatorVersion)
 
 	// Wait for Ready condition to be True
-	capiutil.WaitForCondition(t, ctx, logger, cluster, capi.ReadyCondition, capiconditions.IsTrue, clusterGetter)
 	capiutil.WaitForCondition(t, ctx, logger, azureCluster, capi.ReadyCondition, capiconditions.IsTrue, azureClusterGetter)
 
 	// Check that Cluster and AzureCluster desired release version matches
@@ -113,18 +113,29 @@ func Test_AzureClusterCR(t *testing.T) {
 		t.Fatalf("error finding MachinePools for cluster %q: %s", clusterID, microerror.JSON(err))
 	}
 
-	sort.Slice(machinePools, func(i int, j int) bool {
-		return machinePools[i].Name < machinePools[j].Name
+	var readyMachinePools []capiexp.MachinePool
+	for _, machinePool := range machinePools {
+		if capiconditions.IsTrue(&machinePool, capi.ReadyCondition) {
+			readyMachinePools = append(readyMachinePools, machinePool)
+		}
+	}
+
+	if len(readyMachinePools) < 1 {
+		t.Fatal("there are no 'Ready' node pools to test")
+	}
+
+	sort.Slice(readyMachinePools, func(i int, j int) bool {
+		return readyMachinePools[i].Name < readyMachinePools[j].Name
 	})
 
 	subnets := azureCluster.Spec.NetworkSpec.Subnets
 
 	// Check number of allocated subnets
-	if len(subnets) != len(machinePools) {
+	if len(subnets) != len(readyMachinePools) {
 		t.Fatalf("AzureCluster '%s/%s': expected %d subnets in Spec.NetworkSpec.Subnets (to match number of MachinePools), but got %d instead",
 			azureCluster.Namespace,
 			azureCluster.Name,
-			len(machinePools),
+			len(readyMachinePools),
 			len(subnets))
 	}
 
@@ -135,12 +146,12 @@ func Test_AzureClusterCR(t *testing.T) {
 	const expectedSubnetCIDRBlocks = 1
 	for i := range subnets {
 		// Check if subnet name matches MachinePool name
-		if subnets[i].Name != machinePools[i].Name {
+		if subnets[i].Name != readyMachinePools[i].Name {
 			t.Fatalf("AzureCluster '%s/%s': expected subnet name %q (in Spec.NetworkSpec.Subnets) to match MachinePool name %q",
 				azureCluster.Namespace,
 				azureCluster.Name,
 				subnets[i].Name,
-				machinePools[i].Name)
+				readyMachinePools[i].Name)
 		}
 
 		// Check if we have allocated correct number of CIDR blocks for the subnet

--- a/azurecluster_test.go
+++ b/azurecluster_test.go
@@ -107,7 +107,7 @@ func Test_AzureClusterCR(t *testing.T) {
 	}
 
 	// Check subnets, first we get MachinePools, as we need one subnet per node pool
-	machinePools, err := capiutil.FindMachinePoolsForCluster(ctx, cpCtrlClient, clusterID)
+	machinePools, err := capiutil.FindNonTestingMachinePoolsForCluster(ctx, cpCtrlClient, clusterID)
 	if err != nil {
 		t.Fatalf("error finding MachinePools for cluster %q: %s", clusterID, microerror.JSON(err))
 	}

--- a/azuremachinepool_test.go
+++ b/azuremachinepool_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
 
@@ -58,15 +57,8 @@ func Test_AzureMachinePoolCR(t *testing.T) {
 		t.Fatalf("error finding MachinePools for cluster %q: %s", clusterID, microerror.JSON(err))
 	}
 
-	var readyAzureMachinePools []capzexp.AzureMachinePool
-	for _, azureMachinePool := range azureMachinePools {
-		if capiconditions.IsTrue(&azureMachinePool, capi.ReadyCondition) {
-			readyAzureMachinePools = append(readyAzureMachinePools, azureMachinePool)
-		}
-	}
-
-	if len(readyAzureMachinePools) < 1 {
-		t.Fatal("there are no 'Ready' node pools to test")
+	if len(azureMachinePools) == 0 {
+		t.Fatal("Expected one azure machine pool to exist, none found.")
 	}
 
 	azureMachinePoolGetter := func(azureMachinePoolID string) capiutil.TestedObject {
@@ -87,7 +79,7 @@ func Test_AzureMachinePoolCR(t *testing.T) {
 		return machinePool
 	}
 
-	for _, azureMachinePool := range readyAzureMachinePools {
+	for _, azureMachinePool := range azureMachinePools {
 		amp := azureMachinePool
 
 		//

--- a/azuremachinepool_test.go
+++ b/azuremachinepool_test.go
@@ -52,7 +52,7 @@ func Test_AzureMachinePoolCR(t *testing.T) {
 
 	cluster := clusterGetter(clusterID).(*capi.Cluster)
 
-	azureMachinePools, err := capiutil.FindAzureMachinePoolsForCluster(ctx, cpCtrlClient, clusterID)
+	azureMachinePools, err := capiutil.FindNonTestingAzureMachinePoolsForCluster(ctx, cpCtrlClient, clusterID)
 	if err != nil {
 		t.Fatalf("error finding MachinePools for cluster %q: %s", clusterID, microerror.JSON(err))
 	}

--- a/machinepool_test.go
+++ b/machinepool_test.go
@@ -64,7 +64,7 @@ func Test_MachinePoolCR(t *testing.T) {
 		return machinePool
 	}
 
-	machinePools, err := capiutil.FindMachinePoolsForCluster(ctx, cpCtrlClient, clusterID)
+	machinePools, err := capiutil.FindNonTestingMachinePoolsForCluster(ctx, cpCtrlClient, clusterID)
 	if err != nil {
 		t.Fatalf("error finding MachinePools for cluster %q: %s", clusterID, microerror.JSON(err))
 	}

--- a/machinepool_test.go
+++ b/machinepool_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
-	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -70,18 +69,11 @@ func Test_MachinePoolCR(t *testing.T) {
 		t.Fatalf("error finding MachinePools for cluster %q: %s", clusterID, microerror.JSON(err))
 	}
 
-	var readyMachinePools []capiexp.MachinePool
+	if len(machinePools) == 0 {
+		t.Fatal("Expected one machine pool to exist, none found.")
+	}
+
 	for _, machinePool := range machinePools {
-		if capiconditions.IsTrue(&machinePool, capi.ReadyCondition) {
-			readyMachinePools = append(readyMachinePools, machinePool)
-		}
-	}
-
-	if len(readyMachinePools) < 1 {
-		t.Fatal("there are no 'Ready' node pools to test")
-	}
-
-	for _, machinePool := range readyMachinePools {
 		mp := machinePool
 
 		//

--- a/pkg/capiutil/azuremachinepool.go
+++ b/pkg/capiutil/azuremachinepool.go
@@ -31,10 +31,10 @@ func FindAzureMachinePool(ctx context.Context, client ctrl.Client, azureMachineP
 	return azureMachinePool, nil
 }
 
-// FindAzureMachinePoolsForCluster returns list of `AzureMachinePool` belonging to the
+// FindNonTestingAzureMachinePoolsForCluster returns list of `AzureMachinePool` belonging to the
 // specified cluster ID.
 // It filters out potential `AzureMachinePool` created by other e2e tests.
-func FindAzureMachinePoolsForCluster(ctx context.Context, client ctrl.Client, clusterID string) ([]capzexp.AzureMachinePool, error) {
+func FindNonTestingAzureMachinePoolsForCluster(ctx context.Context, client ctrl.Client, clusterID string) ([]capzexp.AzureMachinePool, error) {
 	var azureMachinePools []capzexp.AzureMachinePool
 	{
 		var azureMachinePoolList capzexp.AzureMachinePoolList

--- a/pkg/capiutil/label.go
+++ b/pkg/capiutil/label.go
@@ -1,0 +1,3 @@
+package capiutil
+
+const E2ENodepool = "e2e"

--- a/pkg/capiutil/machinepool.go
+++ b/pkg/capiutil/machinepool.go
@@ -31,10 +31,10 @@ func FindMachinePool(ctx context.Context, client ctrl.Client, machinePoolID stri
 	return machinePool, nil
 }
 
-// FindMachinePoolsForCluster returns list of `MachinePool` belonging to the
+// FindNonTestingMachinePoolsForCluster returns list of `MachinePool` belonging to the
 // specified cluster ID.
 // It filters out potential `MachinePool` created by other e2e tests.
-func FindMachinePoolsForCluster(ctx context.Context, client ctrl.Client, clusterID string) ([]capiexp.MachinePool, error) {
+func FindNonTestingMachinePoolsForCluster(ctx context.Context, client ctrl.Client, clusterID string) ([]capiexp.MachinePool, error) {
 	var machinePools []capiexp.MachinePool
 	{
 		var machinePoolList capiexp.MachinePoolList

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/azure"
 	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/azure/credentials"
+	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/capiutil"
 	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/randomid"
 )
 
@@ -114,6 +115,7 @@ func (p *AzureProviderSupport) createMachinePool(ctx context.Context, client ctr
 				label.MachinePool:          azureMachinePool.Labels[label.MachinePool],
 				label.Organization:         cluster.Labels[label.Organization],
 				label.ReleaseVersion:       cluster.Labels[label.ReleaseVersion],
+				capiutil.E2ENodepool:       "true",
 			},
 			Annotations: map[string]string{
 				annotation.MachinePoolName: "availability zone verification e2e test",
@@ -166,6 +168,7 @@ func (p *AzureProviderSupport) createAzureMachinePool(ctx context.Context, clien
 				label.MachinePool:          nodepoolName,
 				label.Organization:         cluster.Labels[label.Organization],
 				label.ReleaseVersion:       cluster.Labels[label.ReleaseVersion],
+				capiutil.E2ENodepool:       "true",
 			},
 		},
 		Spec: expcapz.AzureMachinePoolSpec{
@@ -209,6 +212,7 @@ func (p *AzureProviderSupport) createSpark(ctx context.Context, client ctrl.Clie
 				label.Cluster:         cluster.Labels[label.Cluster],
 				label.ReleaseVersion:  cluster.Labels[label.ReleaseVersion],
 				capi.ClusterLabelName: cluster.Name,
+				capiutil.E2ENodepool:  "true",
 			},
 		},
 		Spec: v1alpha1.SparkSpec{},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14803

~There is a test that creates a new node pool, so the assumptions that some tests made about how many resources to find are wrong depending on when they are executed. We don't want a race condition, so I want to try to make assertions only on the `Ready` node pools, because tests are only executed after the created cluster is `Ready`. We are not interested on other node pools that may be created by other tests.~

I changed the approach so instead of filtering out node pools that were not Ready, I'm labeling the cluster that's created for the multi AZ test. That way I can filter out in the rest of the tests.