### PR TITLE
Assert that Spark CR exists for node pool

### DIFF
--- a/error.go
+++ b/error.go
@@ -8,6 +8,11 @@ var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
 }
 
-var missingEnvironmentVariable = &microerror.Error{
-	Kind: "missingEnvironmentVariable",
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
 }

--- a/machinepool_test.go
+++ b/machinepool_test.go
@@ -180,7 +180,7 @@ func findSpark(ctx context.Context, client ctrl.Client, clusterID, machinePoolID
 	var spark *v1alpha1.Spark
 	{
 		var sparkList v1alpha1.SparkList
-		err := client.List(ctx, &sparkList, ctrl.MatchingLabels{label.Cluster: clusterID})
+		err := client.List(ctx, &sparkList, ctrl.MatchingLabels{capi.ClusterLabelName: clusterID})
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15477

Make sure that `Spark` CR exists for every node pool. Since we don't label `Spark` CRs with the node pool name, we need to list all `Spark` CRs in the `Cluster` and then try to find the one named after the node pool.