### PR TITLE
Retry matching number of subnets to number of node pools

### DIFF
--- a/error.go
+++ b/error.go
@@ -16,3 +16,12 @@ var notFoundError = &microerror.Error{
 func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
+
+var unexpectedValueError = &microerror.Error{
+	Kind: "unexpectedValueError",
+}
+
+// IsUnexpectedValueError asserts unexpectedValueError.
+func IsUnexpectedValueError(err error) bool {
+	return microerror.Cause(err) == unexpectedValueError
+}

--- a/pkg/capiutil/azuremachinepool.go
+++ b/pkg/capiutil/azuremachinepool.go
@@ -37,13 +37,12 @@ func FindAzureMachinePool(ctx context.Context, client ctrl.Client, azureMachineP
 func FindNonTestingAzureMachinePoolsForCluster(ctx context.Context, client ctrl.Client, clusterID string) ([]capzexp.AzureMachinePool, error) {
 	var azureMachinePools []capzexp.AzureMachinePool
 	{
-		var azureMachinePoolList capzexp.AzureMachinePoolList
-		err := client.List(ctx, &azureMachinePoolList, ctrl.MatchingLabels{capi.ClusterLabelName: clusterID})
+		azureMachinePoolList, err := FindAllAzureMachinePoolsForCluster(ctx, client, clusterID)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
-		for _, azureMachinePool := range azureMachinePoolList.Items {
+		for _, azureMachinePool := range azureMachinePoolList {
 			_, isE2E := azureMachinePool.Labels[E2ENodepool]
 			if isE2E {
 				continue
@@ -54,4 +53,16 @@ func FindNonTestingAzureMachinePoolsForCluster(ctx context.Context, client ctrl.
 	}
 
 	return azureMachinePools, nil
+}
+
+// FindAllAzureMachinePoolsForCluster returns list of `AzureMachinePool` belonging to the
+// specified cluster ID.
+func FindAllAzureMachinePoolsForCluster(ctx context.Context, client ctrl.Client, clusterID string) ([]capzexp.AzureMachinePool, error) {
+	var azureMachinePoolList capzexp.AzureMachinePoolList
+	err := client.List(ctx, &azureMachinePoolList, ctrl.MatchingLabels{capi.ClusterLabelName: clusterID})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return azureMachinePoolList.Items, nil
 }

--- a/pkg/capiutil/machinepool.go
+++ b/pkg/capiutil/machinepool.go
@@ -37,13 +37,12 @@ func FindMachinePool(ctx context.Context, client ctrl.Client, machinePoolID stri
 func FindNonTestingMachinePoolsForCluster(ctx context.Context, client ctrl.Client, clusterID string) ([]capiexp.MachinePool, error) {
 	var machinePools []capiexp.MachinePool
 	{
-		var machinePoolList capiexp.MachinePoolList
-		err := client.List(ctx, &machinePoolList, ctrl.MatchingLabels{capi.ClusterLabelName: clusterID})
+		machinePoolList, err := FindAllMachinePoolsForCluster(ctx, client, clusterID)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
-		for _, machinePool := range machinePoolList.Items {
+		for _, machinePool := range machinePoolList {
 			_, isE2E := machinePool.Labels[E2ENodepool]
 			if isE2E {
 				continue
@@ -54,4 +53,16 @@ func FindNonTestingMachinePoolsForCluster(ctx context.Context, client ctrl.Clien
 	}
 
 	return machinePools, nil
+}
+
+// FindAllMachinePoolsForCluster returns list of `MachinePool` belonging to the
+// specified cluster ID.
+func FindAllMachinePoolsForCluster(ctx context.Context, client ctrl.Client, clusterID string) ([]capiexp.MachinePool, error) {
+	var machinePoolList capiexp.MachinePoolList
+	err := client.List(ctx, &machinePoolList, ctrl.MatchingLabels{capi.ClusterLabelName: clusterID})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return machinePoolList.Items, nil
 }


### PR DESCRIPTION
This assertion fails every once in a while because a different test creates a new node pool so the number of subnets is not the expected one. I added a retry because eventually they should match.