### PR TITLE
increase timeout for the autoscaler test

### DIFF
--- a/autoscaler_test.go
+++ b/autoscaler_test.go
@@ -112,7 +112,7 @@ func Test_Autoscaler(t *testing.T) {
 
 		return nil
 	}
-	b := backoff.NewConstant(5*time.Minute, 10*time.Second)
+	b := backoff.NewConstant(backoff.LongMaxWait, 10*time.Second)
 	n := backoff.NewNotifier(logger, ctx)
 	err = backoff.RetryNotify(o, b, n)
 	if err != nil {


### PR DESCRIPTION
sometimes 5 minutes for the autoscaler to kick in is not enough