### PR TITLE
increase timeout for the deletion

### DIFF
--- a/deletiontests/azure/azure_delete_test.go
+++ b/deletiontests/azure/azure_delete_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
@@ -107,7 +108,7 @@ func Test_AzureDelete(t *testing.T) {
 
 			return nil
 		}
-		b := backoff.NewConstant(backoff.LongMaxWait, backoff.LongMaxInterval)
+		b := backoff.NewConstant(60*time.Minute, backoff.LongMaxInterval)
 		n := backoff.NewNotifier(logger, ctx)
 		err = backoff.RetryNotify(o, b, n)
 		if err != nil {


### PR DESCRIPTION
My latest test failed because cluster CR wasn't deleted in time.
When I checked, the cluster CR wasn't there so I guess it was a timeout problem.
This PR increases the deletion test timeout

https://tekton.giantswarm.io/#/namespaces/test-workloads/pipelineruns/2960e1a1-0641-11ec-bb04-b613c42b326b