### PR TITLE
Skip now implemented tests on AWS

### DIFF
--- a/autoscaler_test.go
+++ b/autoscaler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/provider"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -49,6 +50,12 @@ func Test_Autoscaler(t *testing.T) {
 	}
 
 	logger := NewTestLogger(regularLogger, t)
+
+	if provider.GetProvider() != "azure" {
+		t.Logf("this test is not implemented on %#q yet, skipping", provider.GetProvider())
+		t.SkipNow()
+		return
+	}
 
 	clusterID, exists := os.LookupEnv("CLUSTER_ID")
 	if !exists {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/conditions/pkg/conditions"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/provider"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
 
@@ -30,6 +31,12 @@ func Test_ClusterCR(t *testing.T) {
 	}
 
 	logger := NewTestLogger(regularLogger, t)
+
+	if provider.GetProvider() != "azure" {
+		t.Logf("this test is not implemented on %#q yet, skipping", provider.GetProvider())
+		t.SkipNow()
+		return
+	}
 
 	clusterID, exists := os.LookupEnv("CLUSTER_ID")
 	if !exists {

--- a/machinepool_test.go
+++ b/machinepool_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/conditions/pkg/conditions"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/provider"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,6 +34,12 @@ func Test_MachinePoolCR(t *testing.T) {
 	}
 
 	logger := NewTestLogger(regularLogger, t)
+
+	if provider.GetProvider() != "azure" {
+		t.Logf("this test is not implemented on %#q yet, skipping", provider.GetProvider())
+		t.SkipNow()
+		return
+	}
 
 	clusterID, exists := os.LookupEnv("CLUSTER_ID")
 	if !exists {

--- a/multiaz_test.go
+++ b/multiaz_test.go
@@ -39,6 +39,12 @@ func Test_AvailabilityZones(t *testing.T) {
 
 	logger := NewTestLogger(regularLogger, t)
 
+	if provider.GetProvider() != "azure" {
+		t.Logf("this test is not implemented on %#q yet, skipping", provider.GetProvider())
+		t.SkipNow()
+		return
+	}
+
 	cpCtrlClient, err := ctrlclient.CreateCPCtrlClient()
 	if err != nil {
 		t.Fatalf("error creating CP k8s client: %v", err)


### PR DESCRIPTION
We have a tekton pipeline called `azure` that runs these tests on azure. We also have another pipeline called `apps` that runs the app test inside this plugin. Instead of having this `apps` pipeline, I believe it's best to have [a new pipeline similar to the `azure` one that runs all these tests on aws clusters](https://github.com/giantswarm/test-infra/pull/148/files).

Since most of these tests are not implemented on aws just yet, this PR skips those tests, but keeps those that should work on all providers. Next time we want to test the apps, we can just run [this new pipeline](https://github.com/giantswarm/test-infra/pull/148/files) that will run the apps test together with other tests, instead of using the `apps` pipeline, that will be removed.