### PR TITLE
fixed legacy cluster test

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/giantswarm/conditions/pkg/conditions"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/provider"
+	corev1 "k8s.io/api/core/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+
+	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/provider"
 
 	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/assert"
 	"github.com/giantswarm/sonobuoy-plugin/v5/pkg/capiutil"
@@ -109,7 +111,9 @@ func Test_ClusterCR(t *testing.T) {
 	}
 
 	if !cluster.Status.ControlPlaneReady {
-		t.Fatalf("control plane is not ready")
+		if capiutil.GetCondition(cluster, capi.ControlPlaneReadyCondition) != corev1.ConditionTrue {
+			t.Fatalf("control plane is not ready")
+		}
 	}
 
 	if !cluster.Status.InfrastructureReady {

--- a/pkg/capiutil/common.go
+++ b/pkg/capiutil/common.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
 )
@@ -68,5 +69,14 @@ func WaitForCondition(t *testing.T, ctx context.Context, logger micrologger.Logg
 			conditionType,
 			objectKind,
 			objectName)
+	}
+}
+
+func GetCondition(obj TestedObject, conditionType capi.ConditionType) corev1.ConditionStatus {
+	cond := capiconditions.Get(obj, conditionType)
+	if cond == nil {
+		return corev1.ConditionUnknown
+	} else {
+		return cond.Status
 	}
 }


### PR DESCRIPTION
The `cluster` test was not working as it was using a `Condition` that we don't have in legacy releases