### PR TITLE
Guard against pod not having ContainerStatuses yet

### DIFF
--- a/networkpolicy_test.go
+++ b/networkpolicy_test.go
@@ -68,6 +68,10 @@ func Test_NetworkPolicy(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			if len(pod.Status.ContainerStatuses) == 0 {
+				return fmt.Errorf("expected pod %s to be have 'ContainerStatuses' but it still has none", successfulPodName)
+			}
+
 			cs := pod.Status.ContainerStatuses[0]
 
 			if cs.State.Terminated != nil {


### PR DESCRIPTION
Not sure if a timing issue or something else is wrong, but it doesn't harm to check for it.

```
--- FAIL: Test_NetworkPolicy (0.11s)
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 62 [running]:
testing.tRunner.func1.2({0x1d87520, 0xc0006d8d68})
        /usr/local/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1212 +0x218
panic({0x1d87520, 0xc0006d8d68})
        /usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/giantswarm/sonobuoy-plugin/v5.Test_NetworkPolicy.func2()
        /app/networkpolicy_test.go:71 +0x23d
github.com/cenkalti/backoff.RetryNotify(0xc00067bf28, {0x7f040ddc43f8, 0xc000831200}, 0xc000831230)
        /go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:37 +0x1ac
github.com/giantswarm/backoff.RetryNotify(0x21e7af8, {0x21b0ea8, 0xc000831200}, 0xc000046090)
        /go/pkg/mod/github.com/giantswarm/backoff@v0.2.0/retry.go:21 +0x49
github.com/giantswarm/sonobuoy-plugin/v5.Test_NetworkPolicy(0xc0000be340)
        /app/networkpolicy_test.go:87 +0x42c
testing.tRunner(0xc0000be340, 0x1f9d2b8)
        /usr/local/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1306 +0x35a
exit status 2
FAIL    github.com/giantswarm/sonobuoy-plugin/v5        0.484s
```