### PR TITLE
scale up nodes by 2 to minimize failed downscaling

### DIFF
--- a/autoscaler_test.go
+++ b/autoscaler_test.go
@@ -93,8 +93,8 @@ func Test_Autoscaler(t *testing.T) {
 
 	logger.Debugf(ctx, "Found %d worker nodes", workersCount)
 
-	// Scale helloworld deployment to len(workers) + 1 replicas to trigger a scale up.
-	expectedWorkersCount := int32(workersCount + 1)
+	// Scale helloworld deployment to len(workers) + 2 replicas to trigger a scale up.
+	expectedWorkersCount := int32(workersCount + 2)
 	logger.Debugf(ctx, "Scaling deployment %s/%s to %d replicas", helloWorldNamespace, helloWorldDeploymentName, expectedWorkersCount)
 	err = scaleDeployment(ctx, tcCtrlClient, expectedWorkersCount)
 	if err != nil {


### PR DESCRIPTION
the autoscaler test fails often because scale down does not happen.
I think it might be because nodes are pretty full and there might not be enough room for all pods to fit.

This PR changes the test to make it scale up by 2 nodes and then back down by 1.
It should minimize the problem from happening